### PR TITLE
Get the API running on Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please submit a pull request if you see anything that can be improved!
 6. **Run the app.**
 
   ```
-  npm start
+  npm run dev
   ```
 
 7. **Open the app.** Open http://localhost:3010/ to see what to do next.

--- a/api/githubLogin.js
+++ b/api/githubLogin.js
@@ -41,7 +41,7 @@ export function setUpGitHubLogin(app) {
 const gitHubStrategyOptions = {
   clientID: GITHUB_CLIENT_ID,
   clientSecret: GITHUB_CLIENT_SECRET,
-  callbackURL: process.env.NODE_ENV !== 'production' ? 'http://localhost:3000/login/github/callback' : 'http://api.githunt.com/login/github/callback',
+  callbackURL: process.env.NODE_ENV !== 'production' ? 'http://localhost:3000/login/github/callback' : 'http://githunt-react.herokuapp.com/login/github/callback',
 };
 
 passport.use(new GitHubStrategy(gitHubStrategyOptions, (accessToken, refreshToken, profile, cb) => {

--- a/api/githubLogin.js
+++ b/api/githubLogin.js
@@ -41,7 +41,7 @@ export function setUpGitHubLogin(app) {
 const gitHubStrategyOptions = {
   clientID: GITHUB_CLIENT_ID,
   clientSecret: GITHUB_CLIENT_SECRET,
-  callbackURL: 'http://localhost:3000/login/github/callback',
+  callbackURL: process.env.NODE_ENV !== 'production' ? 'http://localhost:3000/login/github/callback' : 'http://api.githunt.com/login/github/callback',
 };
 
 passport.use(new GitHubStrategy(gitHubStrategyOptions, (accessToken, refreshToken, profile, cb) => {

--- a/api/githubLogin.js
+++ b/api/githubLogin.js
@@ -41,7 +41,7 @@ export function setUpGitHubLogin(app) {
 const gitHubStrategyOptions = {
   clientID: GITHUB_CLIENT_ID,
   clientSecret: GITHUB_CLIENT_SECRET,
-  callbackURL: process.env.NODE_ENV !== 'production' ? 'http://localhost:3000/login/github/callback' : 'http://githunt-react.herokuapp.com/login/github/callback',
+  callbackURL: process.env.NODE_ENV !== 'production' ? 'http://localhost:3000/login/github/callback' : 'http://www.githunt.com/login/github/callback',
 };
 
 passport.use(new GitHubStrategy(gitHubStrategyOptions, (accessToken, refreshToken, profile, cb) => {

--- a/api/index.js
+++ b/api/index.js
@@ -51,6 +51,8 @@ app.use(
 setUpGitHubLogin(app);
 
 app.use('/graphql', graphqlExpress((req) => {
+  console.log(req.headers)
+
   // Get the query, the same way express-graphql does it
   // https://github.com/graphql/express-graphql/blob/3fa6e68582d6d933d37fa9e841da5d2aa39261cd/src/index.js#L257
   const query = req.query.query || req.body.query;

--- a/api/index.js
+++ b/api/index.js
@@ -25,7 +25,7 @@ import config from './config';
 
 let PORT = 3010;
 if (process.env.PORT) {
-  PORT = parseInt(process.env.PORT, 10) + 100;
+  PORT = parseInt(process.env.PORT, 10);
 }
 
 const WS_PORT = process.env.WS_PORT || 8080;

--- a/api/index.js
+++ b/api/index.js
@@ -51,8 +51,6 @@ app.use(
 setUpGitHubLogin(app);
 
 app.use('/graphql', graphqlExpress((req) => {
-  console.log(req.headers)
-
   // Get the query, the same way express-graphql does it
   // https://github.com/graphql/express-graphql/blob/3fa6e68582d6d933d37fa9e841da5d2aa39261cd/src/index.js#L257
   const query = req.query.query || req.body.query;

--- a/api/index.js
+++ b/api/index.js
@@ -28,8 +28,6 @@ if (process.env.PORT) {
   PORT = parseInt(process.env.PORT, 10);
 }
 
-const WS_PORT = process.env.WS_PORT || 8080;
-
 const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -111,18 +109,10 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-app.listen(PORT, () => console.log( // eslint-disable-line no-console
+const server = createServer(app);
+
+server.listen(PORT, () => console.log( // eslint-disable-line no-console
   `API Server is now running on http://localhost:${PORT}`
-));
-
-// WebSocket server for subscriptions
-const websocketServer = createServer((request, response) => {
-  response.writeHead(404);
-  response.end();
-});
-
-websocketServer.listen(WS_PORT, () => console.log( // eslint-disable-line no-console
-  `Websocket Server is now running on http://localhost:${WS_PORT}`
 ));
 
 // eslint-disable-next-line
@@ -147,5 +137,5 @@ new SubscriptionServer(
       });
     },
   },
-  websocketServer
+  server,
 );

--- a/api/sql/connector.js
+++ b/api/sql/connector.js
@@ -1,6 +1,6 @@
 import knex from 'knex';
-import { development } from '../../knexfile';
+import knexfile from '../../knexfile';
 
 // Eventually we want to wrap Knex to do some batching and caching, but for
 // now this will do since we know none of our queries need it
-export default knex(development);
+export default knex(knexfile[process.env.NODE_ENV || 'development']);

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -51,7 +51,7 @@ export class Comments {
     const query = knex('comments')
       .where({ repository_name: name })
       .count();
-    return query.then(rows => rows.map(row => (row['count(*)'] || '0')));
+    return query.then(rows => rows.map(row => (row['count(*)'] || row.count || '0')));
   }
 
   submitComment(repoFullName, username, content) {

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -58,7 +58,7 @@ export class Comments {
     return knex.transaction(trx => trx('comments')
       .insert({
         content,
-        created_at: Date.now(),
+        created_at: new Date(Date.now()),
         repository_name: repoFullName,
         posted_by: username,
       }));
@@ -237,8 +237,8 @@ export class Entries {
         } else {
           return trx('entries')
             .insert({
-              created_at: Date.now(),
-              updated_at: Date.now(),
+              created_at: new Date(Date.now()),
+              updated_at: new Date(Date.now()),
               repository_name: repoFullName,
               posted_by: username,
             });

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -61,7 +61,8 @@ export class Comments {
         created_at: new Date(Date.now()),
         repository_name: repoFullName,
         posted_by: username,
-      }));
+      })
+      .returning(['id']));
   }
 }
 export class Entries {

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -62,7 +62,7 @@ export class Comments {
         repository_name: repoFullName,
         posted_by: username,
       })
-      .returning(['id']));
+      .returning('id'));
   }
 }
 export class Entries {

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -228,7 +228,7 @@ export class Entries {
     return knex.transaction(trx => trx('entries')
       .count()
       .where('posted_by', '=', username)
-      .where('created_at', '>', Date.now() - rateLimitMs)
+      .where('created_at', '>', new Date(Date.now() - rateLimitMs))
       .then((obj) => {
         // If the user has already submitted too many times, we don't
         // post the repo.

--- a/api/sql/models.js
+++ b/api/sql/models.js
@@ -4,7 +4,7 @@ import knex from './connector';
 
 // A utility function that makes sure we always query the same columns
 function addSelectToEntryQuery(query) {
-  query.select('entries.*', knex.raw('SUM(votes.vote_value) as score'))
+  query.select('entries.*', knex.raw('coalesce(sum(votes.vote_value), 0) as score'))
     .leftJoin('votes', 'entries.id', 'votes.entry_id')
     .groupBy('entries.id');
 }

--- a/knexfile.js
+++ b/knexfile.js
@@ -15,6 +15,6 @@ module.exports = {
   },
   production: DATABASE_URL && {
     client: 'pg',
-    connection: Object.assign({}, parse(DATABASE_URL), { ssl: true }),
+    connection: Object.assign({}, parse(DATABASE_URL), { ssl: false }),
   },
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -15,6 +15,6 @@ module.exports = {
   },
   production: DATABASE_URL && {
     client: 'pg',
-    connection: Object.assign({}, parse(DATABASE_URL), { ssl: false }),
+    connection: Object.assign({}, parse(DATABASE_URL), { ssl: true }),
   },
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,6 +1,10 @@
 // Since Knex always runs this file first, all of our seeds and migrations are babelified.
 require('babel-register');
 
+const { parse } = require('pg-connection-string');
+
+const { PG_URL } = process.env;
+
 module.exports = {
   development: {
     client: 'sqlite3',
@@ -8,5 +12,9 @@ module.exports = {
       filename: './dev.sqlite3',
     },
     useNullAsDefault: true,
+  },
+  production: PG_URL && {
+    client: 'pg',
+    connection: Object.assign({}, parse(PG_URL), { ssl: true }),
   },
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -3,7 +3,7 @@ require('babel-register');
 
 const { parse } = require('pg-connection-string');
 
-const { PG_URL } = process.env;
+const { DATABASE_URL } = process.env;
 
 module.exports = {
   development: {
@@ -13,8 +13,8 @@ module.exports = {
     },
     useNullAsDefault: true,
   },
-  production: PG_URL && {
+  production: DATABASE_URL && {
     client: 'pg',
-    connection: Object.assign({}, parse(PG_URL), { ssl: true }),
+    connection: Object.assign({}, parse(DATABASE_URL), { ssl: true }),
   },
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example app for Apollo",
   "scripts": {
-    "start": "node -r babel-register api/index.js",
+    "start": "babel-node api/index.js",
     "dev": "nodemon api/index.js --watch api --exec babel-node",
     "lint": "eslint api migrations seeds",
     "test": "mocha --compilers js:babel-core/register --reporter spec --full-trace 'api/**/*.test.js' && npm run lint",
@@ -22,12 +22,7 @@
   },
   "homepage": "https://github.com/apollostack/GitHunt#readme",
   "devDependencies": {
-    "babel-cli": "6.16.0",
-    "babel-core": "6.21.0",
     "babel-eslint": "7.1.1",
-    "babel-preset-es2015": "6.16.0",
-    "babel-preset-react": "6.16.0",
-    "babel-preset-stage-2": "6.17.0",
     "babel-register": "6.16.3",
     "chai": "3.5.0",
     "eslint": "3.14.1",
@@ -40,6 +35,11 @@
     "nodemon": "1.11.0"
   },
   "dependencies": {
+    "babel-cli": "6.16.0",
+    "babel-core": "6.21.0",
+    "babel-preset-es2015": "6.16.0",
+    "babel-preset-react": "6.16.0",
+    "babel-preset-stage-2": "6.17.0",
     "body-parser": "1.15.2",
     "connect-session-knex": "1.3.0",
     "dataloader": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Example app for Apollo",
   "scripts": {
-    "start": "nodemon api/index.js --watch api --exec babel-node",
+    "start": "babel-node api/index.js",
+    "dev": "nodemon api/index.js --watch api --exec babel-node",
     "lint": "eslint api migrations seeds",
     "test": "mocha --compilers js:babel-core/register --reporter spec --full-trace 'api/**/*.test.js' && npm run lint",
     "seed": "knex seed:run",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example app for Apollo",
   "scripts": {
-    "start": "babel-node api/index.js",
+    "start": "node -r babel-register api/index.js",
     "dev": "nodemon api/index.js --watch api --exec babel-node",
     "lint": "eslint api migrations seeds",
     "test": "mocha --compilers js:babel-core/register --reporter spec --full-trace 'api/**/*.test.js' && npm run lint",
@@ -25,7 +25,6 @@
     "babel-cli": "6.16.0",
     "babel-core": "6.21.0",
     "babel-eslint": "7.1.1",
-    "babel-loader": "6.2.9",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.17.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.9.0",
     "mocha": "3.2.0",
-    "nodemon": "1.11.0"
+    "nodemon": "1.11.0",
+    "sqlite3": "3.1.8"
   },
   "dependencies": {
     "babel-cli": "6.16.0",
@@ -46,7 +47,6 @@
     "dotenv": "4.0.0",
     "express": "4.14.1",
     "express-session": "1.15.0",
-    "persistgraphql": "^0.2.6",
     "graphql": "^0.9.1",
     "graphql-server-express": "^0.5.2",
     "graphql-subscriptions": "^0.2.3",
@@ -55,9 +55,11 @@
     "lodash": "4.17.4",
     "passport": "0.3.2",
     "passport-github": "1.1.0",
+    "persistgraphql": "^0.2.6",
+    "pg": "^6.1.2",
+    "pg-connection-string": "^0.1.3",
     "reddit-score": "0.0.1",
     "request-promise": "4.1.1",
-    "sqlite3": "3.1.8",
     "subscriptions-transport-ws": "0.2.6"
   }
 }

--- a/seeds/seed.js
+++ b/seeds/seed.js
@@ -100,17 +100,17 @@ export function seed(knex, Promise) {
   // Insert some entries for the repositories
   .then(() => {
     return Promise.all(repos.map(({ repository_name, posted_by }, i) => {
-      const createdAt = Date.now() - (i * 10000);
+      const createdAt = new Date(Date.now() - (i * 10000));
       const repoVotes = votes[repository_name];
       const hotScore = hot(repoVotes, createdAt);
 
       return knex('entries').insert({
         created_at: createdAt,
-        updated_at: Date.now() - (i * 10000),
+        updated_at: createdAt,
         repository_name,
         posted_by,
         hot_score: hotScore,
-      }).then(([id]) => {
+      }).returning('id').then(([id]) => {
         repoIds[repository_name] = id;
       });
     }));


### PR DESCRIPTION
Heroku is not Galaxy, but we can get it running for free, and enable automatic deployments from the GitHub `master` branch. I also considered using https://zeit.co/now/, but couldn’t find an easy way to do automated deployments. Also, the database would reset whenever the container restarts. This wouldn’t be too bad, but it is avoidable when going with Heroku.

The bulk of this PR is enabling the API to run with Postgres in production, and sqlite in development. This is because sqlite does not play nicely with Heroku (https://devcenter.heroku.com/articles/sqlite3). However, we can run a free Postgres database. Thanks to `knex` this change was mostly just a configuration change.

Automatic deploys are currently not enabled. I’ll enable them once we merge this PR. If you want access to the Heroku application, let me know 👍