### PR TITLE
Add private scoping to `currentUser` and a private cache for its storage.

### DIFF
--- a/api/schema.js
+++ b/api/schema.js
@@ -40,7 +40,7 @@ type Query {
   ): Entry
 
   # Return the currently logged in user, or null if nobody is logged in
-  currentUser: User
+  currentUser: User @cacheControl(scope: PRIVATE)
 }
 
 # The type of vote to record, when submitting a vote

--- a/api/server.js
+++ b/api/server.js
@@ -44,7 +44,13 @@ export function run({ ENGINE_API_KEY, PORT: portFromEnv = 3010 } = {}) {
         apiKey: ENGINE_API_KEY,
         stores: [
           {
-            name: 'embeddedCache',
+            name: 'publicResponseCache',
+            inMemory: {
+              cacheSize: 10485760,
+            },
+          },
+          {
+            name: 'privateResponseCache',
             inMemory: {
               cacheSize: 10485760,
             },
@@ -60,12 +66,12 @@ export function run({ ENGINE_API_KEY, PORT: portFromEnv = 3010 } = {}) {
           store: 'pq',
         },
         sessionAuth: {
-          store: 'embeddedCache',
+          store: 'privateResponseCache',
           header: 'Authorization',
         },
         queryCache: {
-          publicFullQueryStore: 'embeddedCache',
-          privateFullQueryStore: 'embeddedCache',
+          publicFullQueryStore: 'publicResponseCache',
+          privateFullQueryStore: 'privateResponseCache',
         },
         reporting: {
           debugReports: true,


### PR DESCRIPTION
While a `User` is used in many different aspects of the app (e.g. the
user who posted a `Comment`, the owner of a `Repository`), the
`currentUser` is intended to be the `User` who is currently authorized to
the app and should not be cached by Engine.

This app is already aware of how to quantify the difference between
sessions by its `sessionAuth.header` configuration in `engineConfig`
(api/server.js).  By adding a `@cacheControl(scope: PRIVATE)` decorator on
the `currentUser` field, we instruct Engine caching that this field
is subject to this isolation.  While the private data will still be
cached, the contents of the cached resource are only available to a user
from the same session (based on the `Authorization` header).

There are further authorization configuration options, and those can be
seen at:

https://www.apollographql.com/docs/engine/caching.html#public-vs-private.