### PR TITLE
Change `express-session` parameters to alleviate session storage.

### DIFF
--- a/api/githubLogin.js
+++ b/api/githubLogin.js
@@ -41,8 +41,17 @@ export function setUpGitHubLogin(app) {
 
   app.use(session({
     secret: config.sessionStoreSecret,
-    resave: true,
-    saveUninitialized: true,
+
+    // Don't re-save the session to the store if it hasn't been modified. A
+    // value of `true` is the default for `resave`, though that is deprecated
+    // and will change in a future version.  Therefore, we set it to `false`.
+    resave: false,
+
+    // If a session is new, but not modified, don't save it to the store. A
+    // value of `true` is the default for `saveUninitialized`, though now
+    // deprecated and will change in the future.  Therefore, we set it `false`.
+    saveUninitialized: false,
+
     store,
   }));
 


### PR DESCRIPTION
The parameters currently being used for the session store (which is
stored in a Postgres table called "sessions", thanks to the
`connect-session-knex`npm) cause sessions to be created for every
request to the server.

As the popularity of this example gains traction, it causes the session
table to fill up unnecessarily quickly due to arbitrary requests being
issued unique session ids.

It shouldn't be necessary to issue sessions for every single request,
especially as session usage on this site is only used for login
purposes.  Additionally, the parameters I've changed (`resave` and
`saveUninitialized`) were already defaulting to `true`, though the
truth-y setting of both of those variables is deprecated, and will no
longer be the default in future versions.

Since our session store supports the `touch` methodology, we can safely
change these to their new recommended values of `false`.

Ref: https://github.com/expressjs/session#resave